### PR TITLE
Zeek JA4L:  fix SYN test

### DIFF
--- a/zeek/ja4l/main.zeek
+++ b/zeek/ja4l/main.zeek
@@ -73,8 +73,11 @@ event new_connection(c: connection) {
     if(!c?$fp) { c$fp = FINGERPRINT::Info(); }
     
     local rp = get_current_packet_header();
-    if (rp?$tcp && rp$tcp$flags != TH_SYN) {
-        return;  
+    if (rp?$tcp) {
+        # Packet must have the SYN flag but not the ACK flag
+        if ((rp$tcp$flags & TH_SYN) == 0 || (rp$tcp$flags & TH_ACK) == TH_ACK) {
+            return;
+        }
     }
 
     c$fp$ja4l$syn = get_current_packet_timestamp();


### PR DESCRIPTION
The Zeek script produces incomplete JA4L fingerprints for certain connections.

For example, here is the output produced for [macos_tcp_flags.pcap](https://github.com/FoxIO-LLC/ja4/blob/main/pcap/macos_tcp_flags.pcap) in the "pcap" directory:
```
   "ja4l": "_3598",
  "ja4ls": "_25178",
```
For this pcap, the problem seems to occur because the script does not recognize SYN packets that contain additional TCP flags.

This pull request modifies the script to recognize any packet that has SYN without ACK.

This issue was previously fixed in the Python [#23](https://github.com/FoxIO-LLC/ja4/pull/23/files) and Rust [#24](https://github.com/FoxIO-LLC/ja4/pull/24/files) implementations. (Issue [22](https://github.com/FoxIO-LLC/ja4/issues/22))